### PR TITLE
Address hugo warnings, remove Google Analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 public/
 resources/
+.hugo_build.lock
 
 # Compiled source #
 ###################

--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@ languageCode = "en-us"
 title = "twmartin.codes"
 theme = "hallo"
 enableRobotsTXT = true
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["taxonomy"]
 
 [Author]
   name = "Ty Martin"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,4 @@
 <head>
-    <script src="js/google-analytics.js" type="application/javascript"></script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">

--- a/static/_headers
+++ b/static/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; style-src 'self' fonts.googleapis.com use.fontawesome.com; font-src 'self' fonts.gstatic.com use.fontawesome.com; script-src 'self' https://www.google-analytics.com https://ajax.cloudflare.com https://static.cloudflareinsights.com; img-src 'self' https://www.google-analytics.com; upgrade-insecure-requests; report-uri https://twmartincodes.report-uri.com/r/d/csp/enforce;
+  Content-Security-Policy: default-src 'self'; style-src 'self' fonts.googleapis.com use.fontawesome.com; connect-src 'self' https://cloudflareinsights.com; font-src 'self' fonts.gstatic.com use.fontawesome.com; script-src 'self' https://ajax.cloudflare.com https://static.cloudflareinsights.com; img-src 'self' https://www.google-analytics.com; upgrade-insecure-requests; report-uri https://twmartincodes.report-uri.com/r/d/csp/enforce;
   NEL: {'report_to':'default','max_age':31536000,'include_subdomains':true}
   Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()
   Referrer-Policy: strict-origin-when-cross-origin

--- a/static/js/google-analytics.js
+++ b/static/js/google-analytics.js
@@ -1,3 +1,0 @@
-window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-ga('create', 'UA-74494245-1', 'auto');
-ga('send', 'pageview');


### PR DESCRIPTION
- Remove deprecated `taxonomyterm`
- Remove Google Analytics
- adjust `.gitignore` for newer Hugo versions